### PR TITLE
configure basic permissions blocks for github actions to satisfy automated code review tools

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write # push to gh-pages branch
+
 jobs:
   publish-website:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: macos-latest


### PR DESCRIPTION
CodeQL is complaining; this should satisfy it.

At some future time we should change the gh-pages deploy to deploy via artifact instead of branch, and restrict the permission to `pages: write` instead of `contents: write`.
