### PR TITLE
remove Point(DoubleArray) constructor

### DIFF
--- a/geojson/api/geojson.api
+++ b/geojson/api/geojson.api
@@ -422,9 +422,6 @@ public final class org/maplibre/spatialk/geojson/Point : org/maplibre/spatialk/g
 	public fun <init> (Lorg/maplibre/spatialk/geojson/Position;)V
 	public fun <init> (Lorg/maplibre/spatialk/geojson/Position;Lorg/maplibre/spatialk/geojson/BoundingBox;)V
 	public synthetic fun <init> (Lorg/maplibre/spatialk/geojson/Position;Lorg/maplibre/spatialk/geojson/BoundingBox;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> ([D)V
-	public fun <init> ([DLorg/maplibre/spatialk/geojson/BoundingBox;)V
-	public synthetic fun <init> ([DLorg/maplibre/spatialk/geojson/BoundingBox;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lorg/maplibre/spatialk/geojson/Position;
 	public final fun component2 ()Lorg/maplibre/spatialk/geojson/BoundingBox;
 	public final fun copy (Lorg/maplibre/spatialk/geojson/Position;Lorg/maplibre/spatialk/geojson/BoundingBox;)Lorg/maplibre/spatialk/geojson/Point;

--- a/geojson/api/geojson.klib.api
+++ b/geojson/api/geojson.klib.api
@@ -446,7 +446,6 @@ final class org.maplibre.spatialk.geojson/MultiPolygon : org.maplibre.spatialk.g
 
 final class org.maplibre.spatialk.geojson/Point : org.maplibre.spatialk.geojson/Geometry { // org.maplibre.spatialk.geojson/Point|null[0]
     constructor <init>(kotlin/Double, kotlin/Double, kotlin/Double? = ..., org.maplibre.spatialk.geojson/BoundingBox? = ...) // org.maplibre.spatialk.geojson/Point.<init>|<init>(kotlin.Double;kotlin.Double;kotlin.Double?;org.maplibre.spatialk.geojson.BoundingBox?){}[0]
-    constructor <init>(kotlin/DoubleArray, org.maplibre.spatialk.geojson/BoundingBox? = ...) // org.maplibre.spatialk.geojson/Point.<init>|<init>(kotlin.DoubleArray;org.maplibre.spatialk.geojson.BoundingBox?){}[0]
     constructor <init>(org.maplibre.spatialk.geojson/Position, org.maplibre.spatialk.geojson/BoundingBox? = ...) // org.maplibre.spatialk.geojson/Point.<init>|<init>(org.maplibre.spatialk.geojson.Position;org.maplibre.spatialk.geojson.BoundingBox?){}[0]
 
     final val bbox // org.maplibre.spatialk.geojson/Point.bbox|{}bbox[0]

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Point.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/Point.kt
@@ -17,12 +17,6 @@ import org.maplibre.spatialk.geojson.serialization.GeoUriParser
 public data class Point
 @JvmOverloads
 constructor(public val coordinates: Position, override val bbox: BoundingBox? = null) : Geometry {
-    @JvmOverloads
-    public constructor(
-        coordinates: DoubleArray,
-        bbox: BoundingBox? = null,
-    ) : this(Position(coordinates), bbox)
-
     public constructor(
         longitude: Double,
         latitude: Double,

--- a/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/PointTest.kt
+++ b/geojson/src/commonTest/kotlin/org/maplibre/spatialk/geojson/PointTest.kt
@@ -24,13 +24,13 @@ class PointTest {
 
     @Test
     fun longitude_doesReturnCorrectValue() {
-        val point = Point(arrayOf(1.0, 2.0, 5.0).toDoubleArray())
+        val point = Point(1.0, 2.0, 5.0)
         assertEquals(1.0, point.coordinates.longitude, DELTA)
     }
 
     @Test
     fun latitude_doesReturnCorrectValue() {
-        val point = Point(arrayOf(1.0, 2.0, 5.0).toDoubleArray())
+        val point = Point(1.0, 2.0, 5.0)
         assertEquals(2.0, point.coordinates.latitude, DELTA)
     }
 


### PR DESCRIPTION
Just like `Position`, where we made this constructor internal because it resulted in a mutable `Position`. This public constructor created a mutable `Point`.