### PR TITLE
chore(deps): pin dependencys to shas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
 
         runs-on: ${{ matrix.runner }}
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
               with:
                   fetch-depth: 0
                   fetch-tags: true
-            - uses: actions/setup-java@v5
+            - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
               with:
                   distribution: temurin
                   java-version: 21
@@ -43,11 +43,11 @@ jobs:
     benchmark:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
               with:
                   fetch-depth: 0
                   fetch-tags: true
-            - uses: actions/setup-java@v5
+            - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
               with:
                   distribution: temurin
                   java-version: 21
@@ -59,16 +59,16 @@ jobs:
     build-docs:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
               with:
                   fetch-depth: 0
                   fetch-tags: true
-            - uses: actions/setup-java@v5
+            - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
               with:
                   distribution: temurin
                   java-version: 21
             - run: ./gradlew :mkdocsBuild
-            - uses: actions/upload-pages-artifact@v4
+            - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
               with:
                   path: build/mkdocs
 
@@ -80,17 +80,17 @@ jobs:
             issues: write
             pull-requests: write
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
               with:
                   fetch-depth: 0
                   fetch-tags: true
-            - uses: actions/setup-java@v5
+            - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
               with:
                   distribution: temurin
                   java-version: 21
-            - uses: pre-commit/action@v3.0.1
+            - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
             - if: ${{ github.event_name == 'pull_request' && always() }}
-              uses: reviewdog/action-suggester@v1
+              uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1.24.0
               with:
                   tool_name: format
                   fail_level: any

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,11 @@ jobs:
             name: maven-central
             url: https://central.sonatype.com/namespace/org.maplibre.spatialk
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
               with:
                   fetch-depth: 0
                   fetch-tags: true
-            - uses: actions/setup-java@v5
+            - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
               with:
                   distribution: temurin
                   java-version: 21
@@ -52,20 +52,20 @@ jobs:
             name: github-pages
             url: ${{ steps.deploy-pages.outputs.page_url }}
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
               with:
                   fetch-depth: 0
                   fetch-tags: true
-            - uses: actions/setup-java@v5
+            - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
               with:
                   distribution: temurin
                   java-version: 21
             - run: |
                   ./gradlew :mkdocsBuild -Psemver.stage=final -Psemver.scope=${{github.event.inputs.scope }}
-            - uses: actions/upload-pages-artifact@v4
+            - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
               with:
                   path: build/mkdocs
-            - uses: actions/deploy-pages@v4
+            - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
               id: deploy-pages
 
     tag:
@@ -74,11 +74,11 @@ jobs:
         permissions:
             contents: write
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
               with:
                   fetch-depth: 0
                   fetch-tags: true
-            - uses: actions/setup-java@v5
+            - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
               with:
                   distribution: temurin
                   java-version: 21

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -33,11 +33,11 @@ jobs:
             name: maven-central
             url: https://central.sonatype.com/namespace/org.maplibre.spatialk
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
               with:
                   fetch-depth: 0
                   fetch-tags: true
-            - uses: actions/setup-java@v5
+            - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
               with:
                   distribution: temurin
                   java-version: 21
@@ -58,17 +58,17 @@ jobs:
         if: ${{ needs.check-last-run.outputs.last_sha != github.sha }}
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
               with:
                   fetch-depth: 0
                   fetch-tags: true
-            - uses: actions/setup-java@v5
+            - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
               with:
                   distribution: temurin
                   java-version: 21
             - run: |
                   ./gradlew :mkdocsBuild -Psemver.stage=snapshot -Psemver.scope=minor
-            - uses: actions/upload-pages-artifact@v4
+            - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
               with:
                   path: build/mkdocs
 
@@ -77,11 +77,11 @@ jobs:
         if: ${{ needs.check-last-run.outputs.last_sha != github.sha }}
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
               with:
                   fetch-depth: 0
                   fetch-tags: true
-            - uses: actions/setup-java@v5
+            - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
               with:
                   distribution: temurin
                   java-version: 21


### PR DESCRIPTION
## Launch Checklist

Our CI uses a few actions.
For these actions, we currently just use the mutable GitHub tag.

Since we use Dependabot to update the versions, we should use SHAs.
This makes sure that we are not affected by a certain class of supply chain vulnerability where attackers re-publish bad tags.

Using SHAs matches GitHub recommendations and is a part of the OpenSSFs Scorecard.


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
       ^--- not sure if you want this. Other maintenance actions don't show up as well.