### PR TITLE
throw MissingFieldException instead of SerializationException when a field is missing

### DIFF
--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/GeoJsonPolymorphicSerializer.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/GeoJsonPolymorphicSerializer.kt
@@ -3,6 +3,8 @@ package org.maplibre.spatialk.geojson.serialization
 import kotlin.collections.get
 import kotlin.reflect.KClass
 import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.json.Json
@@ -30,9 +32,12 @@ internal abstract class GeoJsonPolymorphicSerializer<T : GeoJsonObject>(
 
     private val allowedSerializers by lazy { allSerializers.filter { it.key in allowedTypes } }
 
+    @OptIn(ExperimentalSerializationApi::class)
     override fun selectDeserializer(element: JsonElement): DeserializationStrategy<T> {
         element as? JsonObject ?: throw SerializationException("Expected JSON object")
-        val type = element["type"]?.let { Json.decodeFromJsonElement<String>(it.jsonPrimitive) }
+        val type =
+            element["type"]?.let { Json.decodeFromJsonElement<String>(it.jsonPrimitive) }
+                ?: throw MissingFieldException("type", "GeoJsonObject")
         val actualSerializer =
             allowedSerializers[type]
                 ?: throw SerializationException(

--- a/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/GeometryCollectionSerializer.kt
+++ b/geojson/src/commonMain/kotlin/org/maplibre/spatialk/geojson/serialization/GeometryCollectionSerializer.kt
@@ -2,6 +2,7 @@ package org.maplibre.spatialk.geojson.serialization
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.nullable
@@ -39,13 +40,13 @@ internal object GeometryCollectionSerializer : KSerializer<GeometryCollection> {
         }
     }
 
+    @OptIn(ExperimentalSerializationApi::class)
     override fun deserialize(decoder: Decoder): GeometryCollection {
         return decoder.decodeStructure(descriptor) {
             var type: String? = null
             var bbox: BoundingBox? = null
             var geometries: List<Geometry>? = null
 
-            @OptIn(ExperimentalSerializationApi::class)
             if (decodeSequentially()) {
                 type = decodeSerializableElement(descriptor, 0, typeSerializer)
                 bbox = decodeSerializableElement(descriptor, 1, bboxSerializer)
@@ -60,10 +61,11 @@ internal object GeometryCollectionSerializer : KSerializer<GeometryCollection> {
                 }
             }
 
+            if (type == null) throw MissingFieldException("type", serialName)
+            if (geometries == null) throw MissingFieldException("geometries", serialName)
+
             if (type != serialName)
                 throw SerializationException("Expected type $serialName but found $type")
-            if (geometries == null)
-                throw SerializationException("Expected geometries to be present")
 
             GeometryCollection(geometries, bbox)
         }


### PR DESCRIPTION
this matches the builtin serializers. resolves #244 

stacked on #241, draft mode until that merges.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
