### PR TITLE
Fix WASM bezier spline tests with floating-point tolerance

### DIFF
--- a/testutil/src/commonMain/kotlin/org/maplibre/spatialk/testutil/FloatingPointUtils.kt
+++ b/testutil/src/commonMain/kotlin/org/maplibre/spatialk/testutil/FloatingPointUtils.kt
@@ -1,7 +1,9 @@
 package org.maplibre.spatialk.testutil
 
 import kotlin.math.abs
+import kotlin.test.assertEquals
 import kotlin.test.asserter
+import org.maplibre.spatialk.geojson.LineString
 import org.maplibre.spatialk.geojson.Position
 
 fun assertDoubleEquals(
@@ -30,4 +32,17 @@ fun assertPositionEquals(
 
     assertDoubleEquals(expected.latitude, actual?.latitude, epsilon, message)
     assertDoubleEquals(expected.longitude, actual?.longitude, epsilon, message)
+}
+
+fun assertLineStringEquals(
+    expected: LineString,
+    actual: LineString,
+    epsilon: Double = 0.0001,
+    message: String? = null,
+) {
+    assertEquals(expected.coordinates.size, actual.coordinates.size, "Coordinate count mismatch")
+    expected.coordinates.forEachIndexed { index, expectedPos ->
+        val actualPos = actual.coordinates[index]
+        assertPositionEquals(expectedPos, actualPos, epsilon, (message ?: "") + " at index $index")
+    }
 }

--- a/turf/build.gradle.kts
+++ b/turf/build.gradle.kts
@@ -17,9 +17,6 @@ kotlin {
     }
 }
 
-// TODO: runs but fails bezier spline tests
-tasks.named("wasmJsNodeTest") { enabled = false }
-
 mavenPublishing {
     pom {
         name = "Spatial K Turf"

--- a/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/transformation/BezierSplineTest.kt
+++ b/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/transformation/BezierSplineTest.kt
@@ -1,9 +1,9 @@
 package org.maplibre.spatialk.turf.transformation
 
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.LineString
+import org.maplibre.spatialk.testutil.assertLineStringEquals
 import org.maplibre.spatialk.testutil.readResourceFile
 
 class BezierSplineTest {
@@ -19,7 +19,7 @@ class BezierSplineTest {
                 readResourceFile("transformation/bezierspline/out/bezierIn.json")
             )
 
-        assertEquals(expectedOut.geometry, feature.geometry.bezierSpline())
+        assertLineStringEquals(expectedOut.geometry, feature.geometry.bezierSpline())
     }
 
     @Test
@@ -33,7 +33,7 @@ class BezierSplineTest {
                 readResourceFile("transformation/bezierspline/out/simple.json")
             )
 
-        assertEquals(expectedOut.geometry, feature.geometry.bezierSpline())
+        assertLineStringEquals(expectedOut.geometry, feature.geometry.bezierSpline())
     }
 
     /**
@@ -52,6 +52,6 @@ class BezierSplineTest {
                 readResourceFile("transformation/bezierspline/out/issue-#1063.json")
             )
 
-        assertEquals(expectedOut.geometry, feature.geometry.bezierSpline())
+        assertLineStringEquals(expectedOut.geometry, feature.geometry.bezierSpline())
     }
 }


### PR DESCRIPTION
The bezier spline tests were failing on WASM due to floating-point precision differences. Added assertLineStringEquals helper to testutil that uses epsilon-based comparison instead of exact equality.

Fixes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

