### PR TITLE
fix: RTree.contains returning incorrect result on element without bbox

### DIFF
--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/other/RTree.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/other/RTree.kt
@@ -110,11 +110,9 @@ public class RTree<T : GeoJsonObject>(
     }
 
     override fun contains(element: T): Boolean {
-        val elementWithBbox = element.withBoundingBox()
-        val bbox = elementWithBbox.bbox ?: return false
-
-        val candidates = search(bbox)
-        return candidates.any { it == element }
+        val element = element.withBoundingBox()
+        val bbox = element.bbox ?: return false
+        return search(bbox).any { it == element }
     }
 
     override fun containsAll(elements: Collection<T>): Boolean {
@@ -442,7 +440,6 @@ public class RTree<T : GeoJsonObject>(
     private fun split(insertPath: MutableList<Node<T>>, level: Int) {
         val node = insertPath[level]
         val m = node.children.size
-        val minEntries = this.minEntries
 
         chooseSplitAxis(node, minEntries, m)
 

--- a/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/other/RTreeTest.kt
+++ b/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/other/RTreeTest.kt
@@ -53,6 +53,14 @@ class RTreeTest {
     }
 
     @Test
+    fun testContains() {
+        val feature = Feature(Point(0.0, 0.0), null)
+        val tree = RTree<Feature<Point, Nothing?>>()
+        tree.insert(feature)
+        assertTrue(tree.contains(feature))
+    }
+
+    @Test
     fun testCollides() {
         val features = listOf(Feature(Point(0.0, 0.0), null), Feature(Point(1.0, 1.0), null))
         val tree = RTree<Feature<Point, Nothing?>>()


### PR DESCRIPTION
It always stores objects with a bbox so the equality check did not work on the raw object

