### PR TITLE
[codex] Add bearing conversion docs example

### DIFF
--- a/docs/units/index.md
+++ b/docs/units/index.md
@@ -63,7 +63,9 @@ converting between scalars, lengths, and areas as needed.
 
 `Bearing` represents an absolute geographic heading (e.g., North, East), while `Rotation` represents
 a relative angular displacement. In Kotlin, bearings can be rotated using operators, and the
-difference between two bearings is a rotation.
+difference between two bearings is a rotation. To convert a `Bearing` to a numeric angle, first
+choose a reference direction and range, such as `0..360` degrees clockwise from north or `-180..180`
+degrees relative to north.
 
 === "Kotlin"
 

--- a/units/src/commonTest/kotlin/org/maplibre/spatialk/units/KotlinDocsTest.kt
+++ b/units/src/commonTest/kotlin/org/maplibre/spatialk/units/KotlinDocsTest.kt
@@ -37,6 +37,10 @@ class KotlinDocsTest {
         val turnedRight: Bearing = heading + 90.degrees
         val turnedLeft: Bearing = heading - 45.degrees
         val diff: Rotation = turnedRight - turnedLeft
+
+        val bearing: Bearing = Bearing.Northwest
+        val clockwiseFromNorth: Double = (bearing - Bearing.North).inDegrees
+        val signedFromNorth: Double = Bearing.North.smallestRotationTo(bearing).inDegrees
         // --8<-- [end:bearings]
     }
 


### PR DESCRIPTION
## Summary
Adds a small docs clarification for `Bearing` to address issue #279.

## What Changed
- added two concrete Kotlin snippet examples for converting a `Bearing` to a numeric angle
- clarified in the units docs that callers need to choose a reference direction and range before converting a `Bearing` to a numeric value

## Why
`Bearing` is intentionally more explicit than a raw `Double`, but the docs did not show the conversion patterns discussed in the issue:
- `0..360` degrees clockwise from north
- `-180..180` degrees relative to north

## Validation
- `./gradlew :units:jvmTest --tests "*KotlinDocsTest*"`

Closes #279

Generated with Codex.