### PR TITLE
[codex] Use existing bbox in polygon contains

### DIFF
--- a/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/booleans/contains.kt
+++ b/turf/src/commonMain/kotlin/org/maplibre/spatialk/turf/booleans/contains.kt
@@ -33,7 +33,7 @@ public operator fun PolygonGeometry.contains(pos: Position): Boolean = this.cont
  *   Polygon
  */
 public fun PolygonGeometry.contains(pos: Position, ignoreBoundary: Boolean): Boolean {
-    val bbox = this.computeBbox()
+    val bbox = this.bbox ?: this.computeBbox()
     // normalize to multipolygon
     val polys =
         when (this) {

--- a/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/booleans/PointInPolygonTest.kt
+++ b/turf/src/commonTest/kotlin/org/maplibre/spatialk/turf/booleans/PointInPolygonTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.MultiPolygon
 import org.maplibre.spatialk.geojson.Point
@@ -46,6 +47,26 @@ class PointInPolygonTest {
 
         assertTrue(concavePoly.contains(ptConcaveIn.coordinates), "point inside concave polygon")
         assertFalse(concavePoly.contains(ptConcaveOut.coordinates), "point outside concave polygon")
+    }
+
+    @Test
+    fun testContainsUsesExistingBbox() {
+        val poly = buildPolygon {
+            addRing {
+                add(0.0, 0.0)
+                add(0.0, 100.0)
+                add(100.0, 0.0)
+            }
+        }
+        val ptIn = Point(50.0, 50.0)
+
+        assertTrue(poly.contains(ptIn.coordinates), "point inside simple polygon")
+
+        val polyWithWrongBbox = poly.copy(bbox = BoundingBox(0.0, 0.0, 10.0, 10.0))
+        assertFalse(
+            polyWithWrongBbox.contains(ptIn.coordinates),
+            "contains should respect an existing bbox",
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
Uses an existing `bbox` on `PolygonGeometry.contains` instead of always recomputing the bounding box.

## What Changed
- changed `PolygonGeometry.contains` to use `this.bbox ?: this.computeBbox()`
- added a regression test proving `contains` respects a pre-populated `bbox`

## Why
Issue #290 points out that the current bounding-box optimization is partially negated because `contains` recomputes the bbox on every call, even when the geometry already has one.

This fix lets callers use `withComputedBbox()` to avoid repeated bbox recomputation across repeated `contains` calls.

## Validation
- `./gradlew :turf:jvmTest --tests "*PointInPolygonTest*"`

Closes #290

Generated with Codex.