### PR TITLE
Add polyline encoding module docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ See the [API Reference](api/index.html) for detailed documentation.
 - [`turf`](./turf/index.md) - Turf.js port
 - [`units`](./units/index.md) - Units of measure
 - [`gpx`](./gpx/index.md) - GPX implementation
+- [`polyline-encoding`](./polyline-encoding/index.md) - Google Encoded Polyline Algorithm support
 
 ### Snapshots
 

--- a/docs/polyline-encoding/index.md
+++ b/docs/polyline-encoding/index.md
@@ -1,0 +1,64 @@
+# Polyline Encoding
+
+The `polyline-encoding` module encodes and decodes polylines using
+[Google's Encoded Polyline Algorithm Format](https://developers.google.com/maps/documentation/utilities/polylinealgorithm).
+
+```kotlin
+--8<-- "polyline-encoding/src/commonTest/kotlin/org/maplibre/spatialk/polyline/KotlinDocsTest.kt:example"
+```
+
+Details can be found in the [API reference](../api/polyline-encoding/index.html).
+
+## Installation
+
+=== "Multiplatform"
+
+    ```kotlin
+    commonMain {
+        dependencies {
+            implementation("org.maplibre.spatialk:polyline-encoding:{{ gradle.project_version }}")
+        }
+    }
+    ```
+
+=== "JVM"
+
+    ```kotlin
+    dependencies {
+        implementation("org.maplibre.spatialk:polyline-encoding-jvm:{{ gradle.project_version }}")
+    }
+    ```
+
+## Encoding
+
+`PolylineEncoding.encode` converts a list of `Position` values into a compact encoded string.
+
+```kotlin
+--8<-- "polyline-encoding/src/commonTest/kotlin/org/maplibre/spatialk/polyline/KotlinDocsTest.kt:encode"
+```
+
+## Decoding
+
+`PolylineEncoding.decode` converts an encoded polyline string back into a list of `Position` values.
+It throws `IllegalArgumentException` if the input is malformed.
+
+```kotlin
+--8<-- "polyline-encoding/src/commonTest/kotlin/org/maplibre/spatialk/polyline/KotlinDocsTest.kt:decode"
+```
+
+`PolylineEncoding.decodeOrNull` behaves the same way, but returns `null` on malformed input instead
+of throwing.
+
+```kotlin
+--8<-- "polyline-encoding/src/commonTest/kotlin/org/maplibre/spatialk/polyline/KotlinDocsTest.kt:decodeOrNull"
+```
+
+## Precision
+
+All three methods accept an optional `precision` parameter that controls the number of decimal
+digits used for coordinate values. The default is `5`, which matches the standard Google precision
+of 1e-5. Some services, such as OSRM, use a precision of `6` for 1e-6.
+
+```kotlin
+--8<-- "polyline-encoding/src/commonTest/kotlin/org/maplibre/spatialk/polyline/KotlinDocsTest.kt:precision"
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,8 @@ nav:
           - units/index.md
     - GPX:
           - gpx/index.md
+    - "Polyline Encoding":
+          - polyline-encoding/index.md
     - "API Reference": api/index.html
 
 theme:

--- a/polyline-encoding/src/commonTest/kotlin/org/maplibre/spatialk/polyline/KotlinDocsTest.kt
+++ b/polyline-encoding/src/commonTest/kotlin/org/maplibre/spatialk/polyline/KotlinDocsTest.kt
@@ -1,0 +1,65 @@
+@file:Suppress("UnusedVariable", "unused")
+
+package org.maplibre.spatialk.polyline
+
+import kotlin.test.Test
+import org.maplibre.spatialk.geojson.Position
+
+// These snippets are primarily intended to be included in documentation. Though they exist as
+// part of the test suite, they are not intended to be comprehensive tests.
+
+class KotlinDocsTest {
+    @Test
+    fun example() {
+        // --8<-- [start:example]
+        val positions =
+            listOf(
+                Position(longitude = -120.2, latitude = 38.5),
+                Position(longitude = -120.95, latitude = 40.7),
+                Position(longitude = -126.453, latitude = 43.252),
+            )
+        val encoded = PolylineEncoding.encode(positions)
+        val decoded = PolylineEncoding.decode(encoded)
+        // --8<-- [end:example]
+    }
+
+    @Test
+    fun encode() {
+        // --8<-- [start:encode]
+        val encoded =
+            PolylineEncoding.encode(
+                listOf(
+                    Position(longitude = -120.2, latitude = 38.5),
+                    Position(longitude = -120.95, latitude = 40.7),
+                )
+            )
+        // --8<-- [end:encode]
+    }
+
+    @Test
+    fun decode() {
+        // --8<-- [start:decode]
+        val positions = PolylineEncoding.decode("_p~iF~ps|U_ulLnnqC")
+        // --8<-- [end:decode]
+    }
+
+    @Test
+    fun decodeOrNull() {
+        // --8<-- [start:decodeOrNull]
+        val positions = PolylineEncoding.decodeOrNull("_p~iF~ps|U_ulLnnqC")
+        // --8<-- [end:decodeOrNull]
+    }
+
+    @Test
+    fun precision() {
+        // --8<-- [start:precision]
+        val positions =
+            listOf(
+                Position(longitude = -120.2, latitude = 38.5),
+                Position(longitude = -120.95, latitude = 40.7),
+            )
+        val encoded = PolylineEncoding.encode(positions, precision = 6)
+        val decoded = PolylineEncoding.decode(encoded, precision = 6)
+        // --8<-- [end:precision]
+    }
+}


### PR DESCRIPTION
## Summary
- Add documentation page for the `polyline-encoding` module, covering encoding, decoding, and precision
- Add `KotlinDocsTest` with snippet markers for tested code examples
- Add nav entry in mkdocs.yml and module listing in docs/index.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)