### PR TITLE
Add workflow to label AI-generated PRs

### DIFF
--- a/.github/workflows/label-ai.yml
+++ b/.github/workflows/label-ai.yml
@@ -12,6 +12,6 @@ jobs:
     label:
         runs-on: ubuntu-latest
         steps:
-            - uses: sargunv/ai-pr-detector@a04d6c93ea3900a27a8dafa6be725b61d2176fac # main as of 2026-04-24
+            - uses: sargunv/ai-pr-detector@64b95ea7b4b037eec2a4c7afb62e117fc006d77e # v0.1.0
               with:
                   label: ai-generated

--- a/.github/workflows/label-ai.yml
+++ b/.github/workflows/label-ai.yml
@@ -1,0 +1,23 @@
+name: Label AI-generated PRs
+
+on:
+    # TODO: remove `pull_request` once detection is verified working on main.
+    # `pull_request_target` runs the workflow file from the target branch, so
+    # changes to this file don't take effect until merged. `pull_request` runs
+    # from the PR branch, which lets us iterate.
+    pull_request:
+        types: [opened, reopened, synchronize]
+    pull_request_target:
+        types: [opened, reopened, synchronize]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    label:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: sargunv/ai-pr-detector@a04d6c93ea3900a27a8dafa6be725b61d2176fac # main as of 2026-04-24
+              with:
+                  label: ai-generated

--- a/.github/workflows/label-ai.yml
+++ b/.github/workflows/label-ai.yml
@@ -1,12 +1,6 @@
 name: Label AI-generated PRs
 
 on:
-    # TODO: remove `pull_request` once detection is verified working on main.
-    # `pull_request_target` runs the workflow file from the target branch, so
-    # changes to this file don't take effect until merged. `pull_request` runs
-    # from the PR branch, which lets us iterate.
-    pull_request:
-        types: [opened, reopened, synchronize]
     pull_request_target:
         types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/label-ai.yml` that runs [`sargunv/ai-pr-detector`](https://github.com/sargunv/ai-pr-detector) on every PR and applies the `ai-generated` label when commit author/committer or `Co-authored-by:` trailers indicate AI authorship.
- API-only (no checkout, no compile) — runs in seconds.

## AI usage disclosure
Per the [MapLibre AI policy](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md): the workflow file and the `sargunv/ai-pr-detector` action it consumes were both authored with Claude Code. This very PR is also the test fixture — the commit on this branch carries a `Co-Authored-By: Claude` trailer, which the action should detect and use to apply the `ai-generated` label.

## Test plan
- [x] Workflow runs on this PR
- [x] Action detects the Claude co-author trailer on the commit
- [x] `ai-generated` label is applied automatically
- [ ] Negative control: a follow-up commit with no AI attribution doesn't add a duplicate label / no errors
- [x] Before merge: remove the temporary `pull_request:` trigger so production only uses `pull_request_target`