### PR TITLE
Document gpx, pmtiles, and polyline-encoding in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ val formatted = distance.toString()  // "5000 m"
 val document = Document(
     metadata = Metadata(name = "My GPX File"),
     waypoints = listOf(
-        Waypoint(1.0, 2.0),
-        Waypoint(3.0, 4.0),
+        Waypoint(latitude = 1.0, longitude = 2.0),
+        Waypoint(latitude = 3.0, longitude = 4.0),
     ),
 )
 val gpxString = Gpx.encodeToString(document)
@@ -84,6 +84,7 @@ val gpxString = Gpx.encodeToString(document)
 ### PMTiles
 
 ```kotlin
+// Inside a suspend function or coroutine scope:
 PmTilesArchive.open(source).use { archive ->
     val header = archive.header
     val tile = archive.getDecompressedTile(z = 0, x = 0, y = 0)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,39 @@ val inMeters = distance.inMeters     // 5000.0
 val formatted = distance.toString()  // "5000 m"
 ```
 
+### GPX
+
+```kotlin
+val document = Document(
+    metadata = Metadata(name = "My GPX File"),
+    waypoints = listOf(
+        Waypoint(1.0, 2.0),
+        Waypoint(3.0, 4.0),
+    ),
+)
+val gpxString = Gpx.encodeToString(document)
+```
+
+### PMTiles
+
+```kotlin
+PmTilesArchive.open(source).use { archive ->
+    val header = archive.header
+    val tile = archive.getDecompressedTile(z = 0, x = 0, y = 0)
+}
+```
+
+### Polyline Encoding
+
+```kotlin
+val positions = listOf(
+    Position(longitude = -120.2, latitude = 38.5),
+    Position(longitude = -120.95, latitude = 40.7),
+)
+val encoded = PolylineEncoding.encode(positions)
+val decoded = PolylineEncoding.decode(encoded)
+```
+
 See the [project site](https://maplibre.org/spatial-k/) for more info.
 
 ## Getting Involved

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ It includes:
 - GeoJSON implementation and DSL for building GeoJSON objects
 - Port of Turf.js geospatial analysis functions in pure Kotlin
 - Library for working with units of measure
+- GPX implementation
+- PMTiles v3 archive reader
+- Google Encoded Polyline Algorithm support
 
 Spatial K supports Kotlin Multiplatform and Java projects.
 
@@ -29,6 +32,9 @@ dependencies {
     implementation("org.maplibre.spatialk:geojson:VERSION")
     implementation("org.maplibre.spatialk:turf:VERSION")
     implementation("org.maplibre.spatialk:units:VERSION")
+    implementation("org.maplibre.spatialk:gpx:VERSION")
+    implementation("org.maplibre.spatialk:pmtiles:VERSION")
+    implementation("org.maplibre.spatialk:polyline-encoding:VERSION")
 }
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Aligns the README with the project docs: module list, dependencies, and short code examples for each library.

Adds the three libraries that were documented on the site but omitted from the README:

- `gpx` — GPX implementation
- `pmtiles` — PMTiles v3 archive reader
- `polyline-encoding` — Google Encoded Polyline Algorithm support

Each new module has a `###` section with a minimal example, matching the existing GeoJSON/Turf/Units style.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9470d694-60b2-4857-a45f-c2c263ce6a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9470d694-60b2-4857-a45f-c2c263ce6a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

