### PR TITLE
Add PMTiles Swift package artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,14 @@ jobs:
                   persist-credentials: false
             - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
             - run: ./gradlew version # TODO: remove this once we're confident in our config
-            - run: ./gradlew ${{ matrix.task }}
+            - run: ./gradlew "${{ matrix.task }}"
+            - if: ${{ matrix.runner == 'macos-latest' }}
+              run: mise run test:swift
             - if: ${{ matrix.task == 'build' }} # Kover only supports JVM
               name: Generate coverage summary
               run: |
-                  echo '## Coverage' >> $GITHUB_STEP_SUMMARY
-                  ./gradlew -q :koverLog | tee $GITHUB_STEP_SUMMARY
+                  echo '## Coverage' >> "$GITHUB_STEP_SUMMARY"
+                  ./gradlew -q :koverLog | tee "$GITHUB_STEP_SUMMARY"
 
     benchmark:
         runs-on: ubuntu-latest
@@ -45,8 +47,8 @@ jobs:
             - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
             - name: Run benchmark
               run: |
-                  echo '## Benchmark' >> $GITHUB_STEP_SUMMARY
-                  ./gradlew -q benchmark -PbenchmarkWarmups=1 -PbenchmarkIterations=1 | tee $GITHUB_STEP_SUMMARY
+                  echo '## Benchmark' >> "$GITHUB_STEP_SUMMARY"
+                  ./gradlew -q benchmark -PbenchmarkWarmups=1 -PbenchmarkIterations=1 | tee "$GITHUB_STEP_SUMMARY"
 
     build-docs:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
             matrix:
                 include:
                     # Run full build and most tests on ubuntu
-                    - runner: ubuntu-latest
+                    - runner: ubuntu-24.04
                       task: build
                     # Run windows and macos native tests on those platforms
-                    - runner: windows-latest
+                    - runner: windows-2025
                       task: mingwX64Test
-                    - runner: macos-latest
+                    - runner: macos-26
                       task: macosArm64Test
 
         runs-on: ${{ matrix.runner }}
@@ -30,7 +30,7 @@ jobs:
             - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
             - run: ./gradlew version # TODO: remove this once we're confident in our config
             - run: ./gradlew "${{ matrix.task }}"
-            - if: ${{ matrix.runner == 'macos-latest' }}
+            - if: ${{ matrix.task == 'macosArm64Test' }}
               run: mise run test:swift
             - if: ${{ matrix.task == 'build' }} # Kover only supports JVM
               name: Generate coverage summary
@@ -39,7 +39,7 @@ jobs:
                   ./gradlew -q :koverLog | tee -a "$GITHUB_STEP_SUMMARY"
 
     benchmark:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -51,7 +51,7 @@ jobs:
                   ./gradlew -q benchmark -PbenchmarkWarmups=1 -PbenchmarkIterations=1 | tee -a "$GITHUB_STEP_SUMMARY"
 
     build-docs:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -63,7 +63,7 @@ jobs:
                   path: docs/dist
 
     check-format:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -72,7 +72,7 @@ jobs:
             - run: mise run check
 
     check-integrity:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -92,6 +92,6 @@ jobs:
     # stub to use as a "required" check on github
     all-good:
         needs: [build, check-format, build-docs, benchmark, check-integrity]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - run: echo 'All checks passed!'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
               name: Generate coverage summary
               run: |
                   echo '## Coverage' >> "$GITHUB_STEP_SUMMARY"
-                  ./gradlew -q :koverLog | tee "$GITHUB_STEP_SUMMARY"
+                  ./gradlew -q :koverLog | tee -a "$GITHUB_STEP_SUMMARY"
 
     benchmark:
         runs-on: ubuntu-latest
@@ -48,7 +48,7 @@ jobs:
             - name: Run benchmark
               run: |
                   echo '## Benchmark' >> "$GITHUB_STEP_SUMMARY"
-                  ./gradlew -q benchmark -PbenchmarkWarmups=1 -PbenchmarkIterations=1 | tee "$GITHUB_STEP_SUMMARY"
+                  ./gradlew -q benchmark -PbenchmarkWarmups=1 -PbenchmarkIterations=1 | tee -a "$GITHUB_STEP_SUMMARY"
 
     build-docs:
         runs-on: ubuntu-latest

--- a/.github/workflows/label-ai.yml
+++ b/.github/workflows/label-ai.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
     label:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - uses: sargunv/ai-pr-detector@64b95ea7b4b037eec2a4c7afb62e117fc006d77e # v0.1.0
               with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,7 +112,7 @@ jobs:
         runs-on: macos-latest
         needs: [resolve-version]
         permissions:
-            contents: write
+            contents: read
         env:
             SPATIAL_K_VERSION: ${{ needs.resolve-version.outputs.spatial_k_version }}
             ARTIFACT_DIR_NAME: spatial-k-pmtiles-swift
@@ -133,8 +133,22 @@ jobs:
                       ${{ runner.temp }}/${{ env.ARTIFACT_DIR_NAME }}/SpatialKPmtiles.swiftpm.zip
                       ${{ runner.temp }}/${{ env.ARTIFACT_DIR_NAME }}/SpatialKPmtiles.swiftpm.zip.checksum
                   if-no-files-found: error
+
+    publish-pmtiles-swift-release:
+        runs-on: ubuntu-latest
+        needs: [resolve-version, publish-maven, publish-pmtiles-swift]
+        if: github.ref_type == 'tag'
+        permissions:
+            contents: write
+        env:
+            SPATIAL_K_VERSION: ${{ needs.resolve-version.outputs.spatial_k_version }}
+            ARTIFACT_DIR_NAME: spatial-k-pmtiles-swift
+        steps:
+            - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+              with:
+                  name: spatial-k-pmtiles-swift-${{ env.SPATIAL_K_VERSION }}
+                  path: ${{ runner.temp }}/${{ env.ARTIFACT_DIR_NAME }}
             - name: Upload to GitHub Release
-              if: github.ref_type == 'tag'
               run: |
                   gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 ||
                       gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
     resolve-version:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         env:
             REF_TYPE: ${{ github.ref_type }}
             REF_NAME: ${{ github.ref_name }}
@@ -52,7 +52,7 @@ jobs:
                   echo "latest_release=$latest_release" >> "$GITHUB_OUTPUT"
 
     publish-maven:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         needs: [resolve-version]
         environment:
             name: maven-central
@@ -83,7 +83,7 @@ jobs:
                       ${{ secrets.GPG_PASSPHRASE }}
 
     publish-pages:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         needs: [resolve-version, publish-maven]
         if: github.ref_type == 'tag'
         permissions:
@@ -109,7 +109,7 @@ jobs:
               id: deploy-pages
 
     publish-pmtiles-swift:
-        runs-on: macos-latest
+        runs-on: macos-26
         needs: [resolve-version]
         permissions:
             contents: read
@@ -135,7 +135,7 @@ jobs:
                   if-no-files-found: error
 
     publish-pmtiles-swift-release:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         needs: [resolve-version, publish-maven, publish-pmtiles-swift]
         if: github.ref_type == 'tag'
         permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,16 +16,14 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
-    publish-maven:
+    resolve-version:
         runs-on: ubuntu-latest
-        environment:
-            name: maven-central
-            url: https://central.sonatype.com/namespace/org.maplibre.spatialk
         env:
             REF_TYPE: ${{ github.ref_type }}
             REF_NAME: ${{ github.ref_name }}
         outputs:
             spatial_k_version: ${{ steps.version.outputs.spatial_k_version }}
+            latest_release: ${{ steps.version.outputs.latest_release }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -52,6 +50,21 @@ jobs:
                   )"
                   echo "spatial_k_version=$version" >> "$GITHUB_OUTPUT"
                   echo "latest_release=$latest_release" >> "$GITHUB_OUTPUT"
+
+    publish-maven:
+        runs-on: ubuntu-latest
+        needs: [resolve-version]
+        environment:
+            name: maven-central
+            url: https://central.sonatype.com/namespace/org.maplibre.spatialk
+        env:
+            REF_TYPE: ${{ github.ref_type }}
+            REF_NAME: ${{ github.ref_name }}
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+            - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
             - name: Publish
               run: >
                   mise run publish --mode live
@@ -59,7 +72,7 @@ jobs:
                   --ref-name "$REF_NAME"
                   --latest-release "$LATEST_RELEASE"
               env:
-                  LATEST_RELEASE: ${{ steps.version.outputs.latest_release }}
+                  LATEST_RELEASE: ${{ needs.resolve-version.outputs.latest_release }}
                   ORG_GRADLE_PROJECT_mavenCentralUsername:
                       ${{ secrets.MAVEN_CENTRAL_USERNAME }}
                   ORG_GRADLE_PROJECT_mavenCentralPassword:
@@ -71,7 +84,7 @@ jobs:
 
     publish-pages:
         runs-on: ubuntu-latest
-        needs: [publish-maven]
+        needs: [resolve-version, publish-maven]
         if: github.ref_type == 'tag'
         permissions:
             contents: read
@@ -88,9 +101,47 @@ jobs:
             - name: Build docs
               run: >
                   mise run docs:build --version
-                  "${{ needs.publish-maven.outputs.spatial_k_version }}"
+                  "${{ needs.resolve-version.outputs.spatial_k_version }}"
             - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
               with:
                   path: docs/dist
             - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
               id: deploy-pages
+
+    publish-pmtiles-swift:
+        runs-on: macos-latest
+        needs: [resolve-version]
+        permissions:
+            contents: write
+        env:
+            SPATIAL_K_VERSION: ${{ needs.resolve-version.outputs.spatial_k_version }}
+            ARTIFACT_DIR_NAME: spatial-k-pmtiles-swift
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+            - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+            - name: Build SwiftPM binary artifact
+              run: >
+                  mise run publish:pmtiles-swift
+                  --version "$SPATIAL_K_VERSION"
+                  --output-dir "$RUNNER_TEMP/$ARTIFACT_DIR_NAME"
+            - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              with:
+                  name: spatial-k-pmtiles-swift-${{ env.SPATIAL_K_VERSION }}
+                  path: |
+                      ${{ runner.temp }}/${{ env.ARTIFACT_DIR_NAME }}/SpatialKPmtiles.swiftpm.zip
+                      ${{ runner.temp }}/${{ env.ARTIFACT_DIR_NAME }}/SpatialKPmtiles.swiftpm.zip.checksum
+                  if-no-files-found: error
+            - name: Upload to GitHub Release
+              if: github.ref_type == 'tag'
+              run: |
+                  gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 ||
+                      gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
+
+                  gh release upload "$GITHUB_REF_NAME" \
+                      "$RUNNER_TEMP/$ARTIFACT_DIR_NAME/SpatialKPmtiles.swiftpm.zip" \
+                      "$RUNNER_TEMP/$ARTIFACT_DIR_NAME/SpatialKPmtiles.swiftpm.zip.checksum" \
+                      --clobber
+              env:
+                  GH_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/.build
 /local.properties
 **/build
+/pmtiles/src/Artifacts
 
 /site
 /node_modules

--- a/docs/src/content/docs/pmtiles/index.mdx
+++ b/docs/src/content/docs/pmtiles/index.mdx
@@ -4,6 +4,8 @@ title: "PMTiles"
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
+export const version = import.meta.env.SPATIAL_K_VERSION ?? 'VERSION';
+
 The `pmtiles` module reads [PMTiles v3](https://docs.protomaps.com/pmtiles/) archives from a
 caller-provided byte range source.
 
@@ -32,8 +34,9 @@ Details can be found in the [API reference](/spatial-k/api/dokka/pmtiles/index.h
 
   <TabItem label="Swift">
     Download `SpatialKPmtiles.swiftpm.zip` from the matching
-    [GitHub release](https://github.com/maplibre/spatial-k/releases), extract it, then add the
-    extracted `SpatialKPmtiles` directory as a local Swift package in Xcode or SwiftPM.
+    <a href={`https://github.com/maplibre/spatial-k/releases/tag/v${version}`}>GitHub release</a>,
+    extract it, then add the extracted `SpatialKPmtiles` directory as a local Swift package in Xcode
+    or SwiftPM.
 
     ```swift
     import SpatialKPmtiles

--- a/docs/src/content/docs/pmtiles/index.mdx
+++ b/docs/src/content/docs/pmtiles/index.mdx
@@ -29,6 +29,16 @@ Details can be found in the [API reference](/spatial-k/api/dokka/pmtiles/index.h
     }
     ```
   </TabItem>
+
+  <TabItem label="Swift">
+    Download `SpatialKPmtiles.swiftpm.zip` from the matching
+    [GitHub release](https://github.com/maplibre/spatial-k/releases), extract it, then add the
+    extracted `SpatialKPmtiles` directory as a local Swift package in Xcode or SwiftPM.
+
+    ```swift
+    import SpatialKPmtiles
+    ```
+  </TabItem>
 </Tabs>
 
 ## Specification coverage

--- a/mise-tasks/publish/pmtiles-swift/_default
+++ b/mise-tasks/publish/pmtiles-swift/_default
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#MISE description="Build and package the PMTiles Swift XCFramework for SwiftPM"
+#USAGE flag "--version <version>" help="Spatial K version"
+#USAGE flag "--output-dir <dir>" help="Directory for packaged artifacts"
+
+set -euo pipefail
+
+./gradlew :pmtiles:assembleSpatialKPmtilesKotlinReleaseXCFramework \
+  -PspatialKVersion="${usage_version:?}"
+
+mkdir -p "${usage_output_dir:?}"
+rm -rf "$usage_output_dir/SpatialKPmtiles"
+rm -f "$usage_output_dir/SpatialKPmtiles.swiftpm.zip" \
+  "$usage_output_dir/SpatialKPmtiles.swiftpm.zip.checksum"
+
+rsync -a --copy-links \
+  --include Package.swift \
+  --include "swiftMain/***" \
+  --exclude "*" \
+  pmtiles/src/ \
+  "$usage_output_dir/SpatialKPmtiles/"
+
+mkdir -p "$usage_output_dir/SpatialKPmtiles/Artifacts"
+cp -R \
+  pmtiles/build/XCFrameworks/release/SpatialKPmtilesKotlin.xcframework \
+  "$usage_output_dir/SpatialKPmtiles/Artifacts/SpatialKPmtilesKotlin.xcframework"
+
+(
+  cd "$usage_output_dir"
+  zip -r -X --symlinks SpatialKPmtiles.swiftpm.zip SpatialKPmtiles >/dev/null
+)
+
+swift package compute-checksum "$usage_output_dir/SpatialKPmtiles.swiftpm.zip" \
+  > "$usage_output_dir/SpatialKPmtiles.swiftpm.zip.checksum"

--- a/mise.toml
+++ b/mise.toml
@@ -49,6 +49,10 @@ if [ "$(uname)" != "Darwin" ]; then
 fi
 
 ./gradlew :pmtiles:assembleSpatialKPmtilesKotlinDebugXCFramework
+rm -rf pmtiles/src/Artifacts/SpatialKPmtilesKotlin.xcframework
+mkdir -p pmtiles/src/Artifacts
+ln -s ../../build/XCFrameworks/debug/SpatialKPmtilesKotlin.xcframework \
+  pmtiles/src/Artifacts/SpatialKPmtilesKotlin.xcframework
 swift test --package-path pmtiles/src
 '''
 

--- a/pmtiles/src/Package.swift
+++ b/pmtiles/src/Package.swift
@@ -1,6 +1,36 @@
 // swift-tools-version: 6.0
 
+import Foundation
 import PackageDescription
+
+var targets: [Target] = [
+    .binaryTarget(
+        name: "SpatialKPmtilesKotlin",
+        path: "Artifacts/SpatialKPmtilesKotlin.xcframework"
+    ),
+    .target(
+        name: "SpatialKPmtiles",
+        dependencies: [
+            "SpatialKPmtilesKotlin"
+        ],
+        path: "swiftMain"
+    ),
+]
+
+if FileManager.default.fileExists(atPath: "swiftTest") {
+    targets.append(
+        .testTarget(
+            name: "SpatialKPmtilesDocsTests",
+            dependencies: [
+                "SpatialKPmtiles"
+            ],
+            path: "swiftTest",
+            resources: [
+                .process("Resources")
+            ]
+        )
+    )
+}
 
 let package = Package(
     name: "SpatialKPmtiles",
@@ -16,27 +46,5 @@ let package = Package(
             ]
         )
     ],
-    targets: [
-        .binaryTarget(
-            name: "SpatialKPmtilesKotlin",
-            path: "Artifacts/SpatialKPmtilesKotlin.xcframework"
-        ),
-        .target(
-            name: "SpatialKPmtiles",
-            dependencies: [
-                "SpatialKPmtilesKotlin"
-            ],
-            path: "swiftMain"
-        ),
-        .testTarget(
-            name: "SpatialKPmtilesDocsTests",
-            dependencies: [
-                "SpatialKPmtiles"
-            ],
-            path: "swiftTest",
-            resources: [
-                .process("Resources")
-            ]
-        ),
-    ]
+    targets: targets
 )

--- a/pmtiles/src/Package.swift
+++ b/pmtiles/src/Package.swift
@@ -3,14 +3,23 @@
 import PackageDescription
 
 let package = Package(
-    name: "SpatialKPmtilesSwiftTests",
+    name: "SpatialKPmtiles",
     platforms: [
-        .macOS(.v14)
+        .iOS(.v17),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "SpatialKPmtiles",
+            targets: [
+                "SpatialKPmtiles"
+            ]
+        )
     ],
     targets: [
         .binaryTarget(
             name: "SpatialKPmtilesKotlin",
-            path: "../build/XCFrameworks/debug/SpatialKPmtilesKotlin.xcframework"
+            path: "Artifacts/SpatialKPmtilesKotlin.xcframework"
         ),
         .target(
             name: "SpatialKPmtiles",


### PR DESCRIPTION
Adds an interim SwiftPM package artifact for the PMTiles module. Early Swift consumers can download a complete local package from releases.

Publishing idiomatically requires a Package.swift at some git repo pointing to the published XCFramework binary, so either:
- separate git repo for the package metadata and swift shim
- same git repo, trigger release before tagging, make a bot commit with the Package.swift metadata and xcframework url before tagging the release

both are a bit awkward, so gonna hold off until the utility is proven. 

for now, the shape is:
- download the zip
- extract it locally
- point your project at that