### PR TITLE
Bump xmlutil from 0.91.3 to 1.0.0

### DIFF
--- a/buildSrc/src/main/kotlin/published-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/published-library.gradle.kts
@@ -22,10 +22,7 @@ kotlin {
                 "-Xconsistent-data-class-copy-visibility"
             )
     }
-    abiValidation {
-        @OptIn(ExperimentalAbiValidation::class)
-        enabled = true
-    }
+    @OptIn(ExperimentalAbiValidation::class) abiValidation()
 }
 
 detekt {

--- a/gpx/src/commonMain/kotlin/org/maplibre/spatialk/gpx/Gpx.kt
+++ b/gpx/src/commonMain/kotlin/org/maplibre/spatialk/gpx/Gpx.kt
@@ -1,7 +1,8 @@
 package org.maplibre.spatialk.gpx
 
 import nl.adaptivity.xmlutil.ExperimentalXmlUtilApi
-import nl.adaptivity.xmlutil.serialization.DefaultXmlSerializationPolicy
+import nl.adaptivity.xmlutil.XmlDeclMode
+import nl.adaptivity.xmlutil.core.XmlVersion
 import nl.adaptivity.xmlutil.serialization.XML
 import org.intellij.lang.annotations.Language
 
@@ -9,9 +10,11 @@ import org.intellij.lang.annotations.Language
 public data object Gpx {
     /** The [XML] format configuration for parsing and serializing GPX data. */
     @OptIn(ExperimentalXmlUtilApi::class)
-    public val gpxFormat: XML = XML {
+    public val gpxFormat: XML = XML.v1 {
+        xmlVersion = XmlVersion.XML10
+        xmlDeclMode = XmlDeclMode.Charset
         indentString = "    "
-        policy = DefaultXmlSerializationPolicy.Builder().apply { ignoreUnknownChildren() }.build()
+        policy { ignoreUnknownChildren() }
     }
 
     /**

--- a/gpx/src/commonTest/resources/out/route.gpx
+++ b/gpx/src/commonTest/resources/out/route.gpx
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.topografix.com/GPX/1/1
                          http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1"

--- a/gpx/src/commonTest/resources/out/track.gpx
+++ b/gpx/src/commonTest/resources/out/track.gpx
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.topografix.com/GPX/1/1
                          http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1"

--- a/gpx/src/commonTest/resources/out/waypoints.gpx
+++ b/gpx/src/commonTest/resources/out/waypoints.gpx
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.topografix.com/GPX/1/1
                          http://www.topografix.com/GPX/1/1/gpx.xsd" version="1.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 jetbrains-annotations = "26.1.0"
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 kotlinx-benchmark = "0.4.16"
 kotlinx-coroutines = "1.11.0"
 kotlinx-kover = "0.9.8"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ kotlin-wrappers = "2026.5.6"
 vanniktech-publish = "0.36.0"
 dokka = "2.2.0"
 detekt = "2.0.0-alpha.5"
-xmlutil = "0.91.3"
+xmlutil = "1.0.0"
 
 [libraries]
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }

--- a/hk.pkl
+++ b/hk.pkl
@@ -16,8 +16,8 @@ local allSteps = new Mapping<String, Step> {
   // generators
   ["abi-dump"] {
     glob = List("**/src/commonMain/kotlin/**/*.kt", "**/api/*.api", "**/api/*.klib.api")
-    check = "./gradlew checkLegacyAbi"
-    fix = "./gradlew updateLegacyAbi"
+    check = "./gradlew checkKotlinAbi"
+    fix = "./gradlew updateKotlinAbi"
     exclusive = true
   }
 }

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -1798,7 +1798,16 @@ streamroller@^3.1.3:
     debug "^4.3.4"
     fs-extra "^8.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1816,7 +1825,14 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2053,7 +2069,16 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/package.json
+++ b/package.json
@@ -1,1 +1,1 @@
-{ "name": "spatial-k", "private": true, "packageManager": "pnpm@10.33.2" }
+{ "name": "spatial-k", "private": true }

--- a/pmtiles/api/pmtiles.api
+++ b/pmtiles/api/pmtiles.api
@@ -35,7 +35,6 @@ public final class org/maplibre/spatialk/pmtiles/ArchiveHeader {
 public final class org/maplibre/spatialk/pmtiles/ArchiveLimits {
 	public static final field Companion Lorg/maplibre/spatialk/pmtiles/ArchiveLimits$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (JJJJJJIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getMaxDirectoryCompressedBytes-s-VKNKU ()J
 	public final fun getMaxDirectoryDecompressedBytes-s-VKNKU ()J
 	public final fun getMaxDirectoryDepth ()I
@@ -99,7 +98,6 @@ public final class org/maplibre/spatialk/pmtiles/ArchiveMetadata {
 public final class org/maplibre/spatialk/pmtiles/ArchiveOpenOptions {
 	public static final field Companion Lorg/maplibre/spatialk/pmtiles/ArchiveOpenOptions$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (Lorg/maplibre/spatialk/pmtiles/ValidationMode;Lorg/maplibre/spatialk/pmtiles/ArchiveLimits;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getLimits ()Lorg/maplibre/spatialk/pmtiles/ArchiveLimits;
 	public final fun getValidationMode ()Lorg/maplibre/spatialk/pmtiles/ValidationMode;
 	public final fun toBuilder ()Lorg/maplibre/spatialk/pmtiles/ArchiveOpenOptions$Builder;
@@ -225,7 +223,6 @@ public final class org/maplibre/spatialk/pmtiles/ArchiveWriteCenter {
 public final class org/maplibre/spatialk/pmtiles/ArchiveWriteConfig {
 	public static final field Companion Lorg/maplibre/spatialk/pmtiles/ArchiveWriteConfig$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (ILorg/maplibre/spatialk/pmtiles/ArchiveWriteBounds;Lorg/maplibre/spatialk/pmtiles/ArchiveWriteCenter;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getBounds ()Lorg/maplibre/spatialk/pmtiles/ArchiveWriteBounds;
 	public final fun getCenter ()Lorg/maplibre/spatialk/pmtiles/ArchiveWriteCenter;
 	public final fun getMetadataJson ()Ljava/lang/String;
@@ -253,7 +250,6 @@ public final class org/maplibre/spatialk/pmtiles/ArchiveWriteConfig$Companion {
 public final class org/maplibre/spatialk/pmtiles/ArchiveWriteLimits {
 	public static final field Companion Lorg/maplibre/spatialk/pmtiles/ArchiveWriteLimits$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (JJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getMaxArchiveBytes-s-VKNKU ()J
 	public final fun getMaxDirectoryBytes-s-VKNKU ()J
 	public final fun getMaxMetadataBytes-s-VKNKU ()J
@@ -284,7 +280,6 @@ public final class org/maplibre/spatialk/pmtiles/ArchiveWriteLimits$Companion {
 public final class org/maplibre/spatialk/pmtiles/ArchiveWriteOptions {
 	public static final field Companion Lorg/maplibre/spatialk/pmtiles/ArchiveWriteOptions$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (IILorg/maplibre/spatialk/pmtiles/ArchiveWriteLimits;ZLjava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDeduplicateTilePayloads ()Z
 	public final fun getInternalCompression-KaDf8nc ()I
 	public final fun getLimits ()Lorg/maplibre/spatialk/pmtiles/ArchiveWriteLimits;
@@ -585,7 +580,6 @@ public final class org/maplibre/spatialk/pmtiles/TileRange {
 public final class org/maplibre/spatialk/pmtiles/TileReadCoalescing {
 	public static final field Companion Lorg/maplibre/spatialk/pmtiles/TileReadCoalescing$Companion;
 	public fun <init> ()V
-	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getMaxCoalescedBytes-s-VKNKU ()J
 	public final fun getMaxGapBytes-s-VKNKU ()J
 	public final fun toBuilder ()Lorg/maplibre/spatialk/pmtiles/TileReadCoalescing$Builder;


### PR DESCRIPTION
Fixes for #356, opening as a new PR for review. Also includes Kotlin 2.4 (#345)